### PR TITLE
Fix hot reloading on development mode

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,5 +6,12 @@ import sitemap from '@astrojs/sitemap';
 // https://astro.build/config
 export default defineConfig({
 	site: 'https://example.com',
+	vite: {
+		server: {
+			watch: {
+				usePolling: true,
+			}
+		}
+	},
 	integrations: [mdx(), sitemap()],
 });


### PR DESCRIPTION
When you run the project in development mode with `npm run dev` the hot load replacement does not work and to watch any changes you need to restart the server. This error only occurs when you are using WSL2. This PR fixed that, setting the `usePolling` to `true`.